### PR TITLE
Fix extension for Grape 1.2+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,14 @@
 language: ruby
 
 rvm:
-  - 2.2.4
+  - 2.6.3
+  - 2.5.4
+  - 2.4.5
 
-before_install: gem install bundler -v 1.11.2
+before_install: gem install bundler
 
 env:
   matrix:
     - GRAPE=HEAD
-    - GRAPE=0.15.0
-    - GRAPE=0.14.0
-    - GRAPE=0.13.0
-    - GRAPE=0.12.0
-    - GRAPE=0.11.0
-    - GRAPE=0.10.0
-    - GRAPE=0.9.0
-    - GRAPE=0.8.0
-    - GRAPE=0.7.0
-    - GRAPE=0.6.0
+    - GRAPE=1.2.4
+    - GRAPE=1.2.0

--- a/grape-cancan.gemspec
+++ b/grape-cancan.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'grape', '~> 1.2'
   spec.add_dependency 'cancancan'
 
-  spec.add_development_dependency 'bundler', '~> 1.11'
+  spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'minitest', '~> 5.8.4'
   spec.add_development_dependency 'rack-test'

--- a/grape-cancan.gemspec
+++ b/grape-cancan.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'grape', '>= 0.6.0'
+  spec.add_dependency 'grape', '~> 1.2'
   spec.add_dependency 'cancancan'
 
   spec.add_development_dependency 'bundler', '~> 1.11'

--- a/lib/grape/cancan.rb
+++ b/lib/grape/cancan.rb
@@ -28,5 +28,5 @@ module Grape
   end
 end
 
-Grape::API.extend Grape::CanCan::API
+Grape::API::Instance.extend Grape::CanCan::API
 Grape::Endpoint.send :include, Grape::CanCan::Endpoint

--- a/lib/grape/cancan/version.rb
+++ b/lib/grape/cancan/version.rb
@@ -1,5 +1,5 @@
 module Grape
   module CanCan
-    VERSION = "0.0.2"
+    VERSION = "0.0.3"
   end
 end


### PR DESCRIPTION
Grape 1.2 changed the way that `Grape::API` is patched to reference `Grape::API::Instance` instead.  See: https://github.com/ruby-grape/grape/blob/master/UPGRADING.md#changes-in-the-grapeapi-class

This PR is just to change that to work with `grape-cancan`, and also update the `grape` dependency to not include any cases with the old manner of doing things.