### PR TITLE
Allow Grape version 2.0 to be used with grape-cancan

### DIFF
--- a/grape-cancan.gemspec
+++ b/grape-cancan.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'grape', '~> 1.2'
+  spec.add_dependency 'grape', '>= 1.0'
   spec.add_dependency 'cancancan'
 
   spec.add_development_dependency 'bundler', '~> 2.0'


### PR DESCRIPTION
Grape released version 2.0.0 with rails 7.1 and rack 3.x support. [Here is the list](https://github.com/ruby-grape/grape/blob/v2.0.0/CHANGELOG.md#200-20231111) of the changes. 

The current gemspec limits us to version 1.x only. This PR removes that limit. The tests are passing locally against Grape 2.0.0.